### PR TITLE
Fix: missing declaration of check_loopback_mode_W6x00

### DIFF
--- a/examples/tcp_server_multi_socket/wizchip_tcp_server_multi_socket.c
+++ b/examples/tcp_server_multi_socket/wizchip_tcp_server_multi_socket.c
@@ -95,7 +95,11 @@ static void set_clock_khz(void)
 int8_t sn = 0;
 int32_t loopback_tcps_multi_socket(uint8_t *buf, uint16_t port)
 {
+#if _WIZCHIP_ > W5500
     check_loopback_mode_W6x00();
+#endif
+
+
     int32_t ret;
     uint16_t size = 0, sentsize = 0;
     uint8_t destip[4];


### PR DESCRIPTION
When building the project with set(BOARD_NAME W5500_EVB_PICO), the build process fails due to an undefined reference to the function check_loopback_mode_W6x00. This suggests that the implementation or declaration of this function is missing or not included in the build for this specific board configuration. It may be necessary to conditionally include this function or ensure the appropriate source file is compiled when targeting W5500_EVB_PICO